### PR TITLE
Fix deleção de recursos

### DIFF
--- a/flood/endpoints/groups.py
+++ b/flood/endpoints/groups.py
@@ -47,11 +47,10 @@ def get_group(group_id):
 
 @blueprint.route('/groups/<group_id>', methods=['DELETE'])
 def delete_group(group_id):
-    group = group_model.get(group_id)
+    group = group_model.delete(group_id)
     if group is None:
         raise endpoints_exception(404, "GROUP_NOT_FOUND")
 
-    group_model.delete(group)
     return jsonify(group.to_dict()), 200
 
 

--- a/flood/endpoints/messages.py
+++ b/flood/endpoints/messages.py
@@ -68,11 +68,10 @@ def get_message(message_id):
 
 @blueprint.route('/messages/<message_id>', methods=['DELETE'])
 def delete_message(message_id):
-    message = message_model.get(message_id)
+    message = message_model.delete(message_id)
     if message is None:
         raise endpoints_exception(404, "GROUP_NOT_FOUND")
 
-    message_model.delete(message)
     return jsonify(message.to_dict()), 200
 
 

--- a/flood/endpoints/users.py
+++ b/flood/endpoints/users.py
@@ -112,9 +112,9 @@ def update_user_geolocation(user_id):
 
     latitude = body.get('latitude')
     longitude = body.get('longitude')
-    groups = group_model.list()
+    groups = group_model.list(None)
     for group in groups:
-        distance = geolocation_utils.check_range(latitude,longitude, group)
+        distance = geolocation_utils.check_range(latitude, longitude, group)
         if distance is not None:
             user_group_model.associate(group, user)
             aux = group.to_dict()
@@ -127,7 +127,7 @@ def update_user_geolocation(user_id):
 
 
 @blueprint.route('/users/<user_id>/groups', methods=['GET', 'OPTIONS'])
-def get_user_grops(user_id):
+def get_user_groups(user_id):
     result = []
 
     user = user_model.get(user_id)

--- a/flood/endpoints/users.py
+++ b/flood/endpoints/users.py
@@ -47,11 +47,11 @@ def get_user(user_id):
 
 @blueprint.route('/users/<user_id>', methods=['DELETE'])
 def delete_user(user_id):
-    user = user_model.get(user_id)
+    user = user_model.delete(user_id)
     if user is None:
         raise endpoints_exception(404, "USER_NOT_FOUND")
 
-    user_model.delete(user)
+
     return jsonify(user.to_dict()), 200
 
 

--- a/flood/models/group.py
+++ b/flood/models/group.py
@@ -136,13 +136,15 @@ def get(session, id):
 
 
 @db_session
-def delete(session, group):
+def delete(session, group_id):
     _logger.info(
-        "DELETING_GROUP_MODEL: {}".format(group.to_dict()),
+        "DELETING_GROUP_MODEL: {}".format(group_id),
     )
-    x = session.query(Group).get(group.id)
+    x = session.query(Group).get(group_id)
+    r = to_dict(x)
     session.delete(x)
     session.commit()
+    return buid_object_from_row(r)
 
 
 

--- a/flood/models/message.py
+++ b/flood/models/message.py
@@ -139,13 +139,15 @@ def get(session, id):
 
 
 @db_session
-def delete(session, message):
+def delete(session, message_id):
     _logger.info(
-        "DELETING_MESSAGE_MODEL: {}".format(message.to_dict()),
+        "DELETING_MESSAGE_MODEL: {}".format(message_id),
     )
-    x = session.query(Message).get(message.id)
+    x = session.query(Message).get(message_id)
+    r = to_dict(x)
     session.delete(x)
     session.commit()
+    return buid_object_from_row(r)
 
 @db_session
 def get_user_messages(session, user, groups, start_date):

--- a/flood/models/user.py
+++ b/flood/models/user.py
@@ -130,10 +130,12 @@ def get_by_email(session, email):
 
 
 @db_session
-def delete(session, user):
+def delete(session, user_id):
     _logger.info(
-        "DELETING_USER_MODEL: {}".format(user.to_dict()),
+        "DELETING_USER_MODEL: {}".format(user_id),
     )
-    x = session.query(Group).get(user.id)
+    x = session.query(User).get(user_id)
+    r = to_dict(x)
     session.delete(x)
     session.commit()
+    return buid_object_from_row(r)

--- a/flood/models/user_groups.py
+++ b/flood/models/user_groups.py
@@ -29,8 +29,8 @@ class UserGroup(Base):
     user_id = Column(mysql.VARCHAR(length=64), ForeignKey(User.id, ondelete='CASCADE'), primary_key=True)
     group_id = Column(mysql.VARCHAR(length=64), ForeignKey(Group.id, ondelete='CASCADE'), primary_key=True)
 
-    user = relationship(User, backref=backref("employee_assoc"))
-    group = relationship(Group, backref=backref("department_assoc"))
+    user = relationship(User, backref=backref("employee_assoc", cascade="all, delete-orphan"))
+    group = relationship(Group, backref=backref("department_assoc", cascade="all, delete-orphan"))
 
     def __repr__(self):
         return f"<UserGrop(user={self.user_id}, group={self.group_id})>"


### PR DESCRIPTION
- Os objetos não estavam sendo referenciados corretamente na deleção
    - Fix na deleção de Grupos
    - Fix na deleção de Usuários
    - Fix na deleção de Mensagens
- Tabela de associação entre usuários e grupos ainda não possuia politicas de deleção.

Agora, recursos estão sendo deletados corretamente, assim como seus recursos "filhos" na hierarquia. Exemplos:

- Quando deletamos um usuário, todas as mensagens deste usuário são deletadas. O mesmo ocorre com um grupo. 
-Quando deletamos um usuário, registros de associações deste usuário a um grupo são deletados. Novamente, o comportamento é o mesmo nos grupos.
- Deletar a mensagem só deleta a mensagem mesmo. :shipit: 