### PR TITLE
Endpoint para validação de seesion agora funciona como wrapper

### DIFF
--- a/TIS5.postman_collection.json
+++ b/TIS5.postman_collection.json
@@ -15,7 +15,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\": \"Bernardo Vasconcelos\",\n\t\"latitude\" : -19.974021,\n\t\"longitude\": -43.970320,\n\t\"range\": 2,\n\t\"active\": true\n}",
+							"raw": "{\n\t\"name\": \"Bernardo Vasconcelos\",\n\t\"latitude\" : -19.8762564,\n\t\"longitude\": -43.9311202,\n\t\"range\": 2,\n\t\"active\": true\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -171,7 +171,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"email\": \"teste@email.com\",\n\t\"name\": \"teste\",\n\t\"pswd\": \"teste\",\n\t\"adm\": true\n}",
+							"raw": "{\n\t\"email\": \"teste@email.com\",\n\t\"name\": \"teste\",\n\t\"pswd\": \"teste\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -186,34 +186,6 @@
 							],
 							"path": [
 								"users"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "validate user session",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"token\": \"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiODRiMWI0NGMtZTFhOS00NGJmLWE3YTktZGVlOTY0ODcyMTZiIiwiZW1haWwiOiJsdWNhc0BlbWFpbC5jb20iLCJwc3dkIjoiZmUyNjQyNzljZmYyNDMwZDMzZGIzZjg3OGQzYjk3ZDIiLCJleHAiOjE1ODY4MDY4NzV9.aYgbju71a67bif8pkbsVrjw_QEw4Pi0SRd-nEaDc_rg\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://{{host}}/users/session",
-							"protocol": "http",
-							"host": [
-								"{{host}}"
-							],
-							"path": [
-								"users",
-								"session"
 							]
 						}
 					},
@@ -315,7 +287,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"pswd\": \"samba123\",\n\t\"email\": \"lucas@email.com\"\n}",
+							"raw": "{\n\t\"email\": \"teste@email.com\",\n\t\"pswd\": \"teste\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -351,7 +323,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/users/<id>/geolocation",
+							"raw": "http://{{host}}/users/<id>/geolocation?token=<token>",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -360,6 +332,12 @@
 								"users",
 								"<id>",
 								"geolocation"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "<token>"
+								}
 							]
 						}
 					},
@@ -383,14 +361,14 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/users/<id>/groups",
+							"raw": "http://{{host}}/users/<user_id>/groups?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiOWExZjFiY2YtMzA3MC00Y2IxLWI4MmItMTBjOGFmOTY2OTVhIiwiZW1haWwiOiJ0ZXN0ZUBlbWFpbC5jb20iLCJwc3dkIjoiNjk4ZGMxOWQ0ODljNGU0ZGI3M2UyOGE3MTNlYWIwN2IiLCJleHAiOjE1ODkxMzMzMjZ9.5aQ6biARh12pgEi3LXHidiBTzduPvoOtwIYELQ7guys",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
 							"path": [
 								"users",
-								"<id>",
+								"<user_id>",
 								"groups"
 							],
 							"query": [
@@ -403,6 +381,10 @@
 									"key": "longitude",
 									"value": "-43.968458",
 									"disabled": true
+								},
+								{
+									"key": "token",
+									"value": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiOWExZjFiY2YtMzA3MC00Y2IxLWI4MmItMTBjOGFmOTY2OTVhIiwiZW1haWwiOiJ0ZXN0ZUBlbWFpbC5jb20iLCJwc3dkIjoiNjk4ZGMxOWQ0ODljNGU0ZGI3M2UyOGE3MTNlYWIwN2IiLCJleHAiOjE1ODkxMzMzMjZ9.5aQ6biARh12pgEi3LXHidiBTzduPvoOtwIYELQ7guys"
 								}
 							]
 						}
@@ -427,7 +409,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/users/<id>/messages",
+							"raw": "http://{{host}}/users/<id>/messages?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiOWExZjFiY2YtMzA3MC00Y2IxLWI4MmItMTBjOGFmOTY2OTVhIiwiZW1haWwiOiJ0ZXN0ZUBlbWFpbC5jb20iLCJwc3dkIjoiNjk4ZGMxOWQ0ODljNGU0ZGI3M2UyOGE3MTNlYWIwN2IiLCJleHAiOjE1ODkxMzMzMjZ9.5aQ6biARh12pgEi3LXHidiBTzduPvoOtwIYELQ7guys",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -442,6 +424,10 @@
 									"key": "start_date",
 									"value": "2020-04-10T23:47:56",
 									"disabled": true
+								},
+								{
+									"key": "token",
+									"value": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiOWExZjFiY2YtMzA3MC00Y2IxLWI4MmItMTBjOGFmOTY2OTVhIiwiZW1haWwiOiJ0ZXN0ZUBlbWFpbC5jb20iLCJwc3dkIjoiNjk4ZGMxOWQ0ODljNGU0ZGI3M2UyOGE3MTNlYWIwN2IiLCJleHAiOjE1ODkxMzMzMjZ9.5aQ6biARh12pgEi3LXHidiBTzduPvoOtwIYELQ7guys"
 								}
 							]
 						}
@@ -469,7 +455,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/messages?group_id=82f4ff41-015f-4955-83cb-88593db27300&user_id=prexos",
+							"raw": "http://{{host}}/messages?group_id=<group_id>&user_id=<user_id>&token=<token>",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -480,11 +466,15 @@
 							"query": [
 								{
 									"key": "group_id",
-									"value": "82f4ff41-015f-4955-83cb-88593db27300"
+									"value": "<group_id>"
 								},
 								{
 									"key": "user_id",
-									"value": "prexos"
+									"value": "<user_id>"
+								},
+								{
+									"key": "token",
+									"value": "<token>"
 								}
 							]
 						}

--- a/flood/endpoints/messages.py
+++ b/flood/endpoints/messages.py
@@ -5,7 +5,7 @@ import flood.models.message as message_model
 import flood.models.group as group_model
 import flood.models.user as user_model
 from flask import Blueprint, jsonify, request
-from flood.utils import body_validations, query_param_validations
+from flood.utils import body_validations, query_param_validations, jwt_token
 from flood.endpoints import endpoints_exception
 
 import logging
@@ -41,6 +41,7 @@ def get_messages():
 
 
 @blueprint.route('/messages', methods=['POST'])
+@jwt_token.token_required
 def post_message():
     body = request.json
     query_param_validations.validate_message(request.args)

--- a/flood/endpoints/users.py
+++ b/flood/endpoints/users.py
@@ -7,7 +7,7 @@ import flood.models.message as message_model
 import flood.models.user_groups as user_group_model
 
 from flask import Blueprint, jsonify, request
-from flood.utils import body_validations, password_utils, query_param_validations, geolocation_utils, jwt_token
+from flood.utils import body_validations, password_utils, geolocation_utils, jwt_token
 from flood.endpoints import endpoints_exception
 
 import logging
@@ -79,28 +79,13 @@ def auth_user():
         return jsonify(result), 200
 
 
-@blueprint.route('/users/session', methods=['POST'])
-def validate_user():
-    body = request.json
-    body_validations.validate_session(body)
-    payload = jwt_token.jwt_decode(body['token'])
-    user = user_model.get(payload['user_id'])
-
-    if user is None:
-        raise endpoints_exception(404, "USER_NOT_FOUND")
-
-    if payload['pswd'] != user.pswd:
-        raise endpoints_exception(401, "UNAUTHORIZED")
-
-    return jsonify({'Message': "Success"}), 200
-
-
 ####################################
 #            GEOLOCATION           #
 ####################################
 
 
 @blueprint.route('/users/<user_id>/geolocation', methods=['POST'])
+@jwt_token.token_required
 def update_user_geolocation(user_id):
     result = []
     body = request.json
@@ -124,9 +109,8 @@ def update_user_geolocation(user_id):
     return jsonify(result), 200
 
 
-
-
 @blueprint.route('/users/<user_id>/groups', methods=['GET', 'OPTIONS'])
+@jwt_token.token_required
 def get_user_groups(user_id):
     result = []
 
@@ -151,7 +135,9 @@ def get_user_groups(user_id):
 #            MESSAGES              #
 ####################################
 
+
 @blueprint.route('/users/<user_id>/messages', methods=['GET', 'OPTIONS'])
+@jwt_token.token_required
 def get_user_messages(user_id):
 
     result = []

--- a/flood/utils/body_validations.py
+++ b/flood/utils/body_validations.py
@@ -46,12 +46,3 @@ def validate_auth(body):
             raise endpoints_exception(400, f"BAD REQUEST: Missing {key} on body")
         if body[key] is None:
             raise endpoints_exception(400, f"BAD REQUEST: Missing {key} value on body")
-
-
-def validate_session(body):
-    required_keys = ['token']
-    for key in required_keys:
-        if key not in body.keys():
-            raise endpoints_exception(400, f"BAD REQUEST: Missing {key} on body")
-        if body[key] is None:
-            raise endpoints_exception(400, f"BAD REQUEST: Missing {key} value on body")

--- a/flood/utils/query_param_validations.py
+++ b/flood/utils/query_param_validations.py
@@ -18,3 +18,11 @@ def validate_group_list_filters(args):
         raise endpoints_exception(400, f"BAD REQUEST: Invalid value for query param active")
     else:
         return True
+
+
+def validate_token(args):
+    required_keys = ['token']
+    for key in required_keys:
+        if key not in args.keys():
+            raise endpoints_exception(400, f"BAD REQUEST: Missing query param {key}")
+    return args['token']


### PR DESCRIPTION
- Endpoint previamente criado para validação do Token JWT agora se tornou um **wrapper** na validação de outros requestes, elas são:
  - GET /users/<user_id>/messages;
  - GET /users/<user_id>/groups;
  - PUT /users/<user_id>/geolocation;
  - POST /messages.
- Para realizar o acesso a esses Endpoints agora o parâmetro **token** deve ser adicionado a suas queries. 