### PR TITLE
Token validation added to others Endpoints

### DIFF
--- a/TIS5.postman_collection.json
+++ b/TIS5.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3ca772dd-3e99-46ac-a8c2-d1c1eae35064",
+		"_postman_id": "ff25c8be-0286-4528-8976-c7165de8f633",
 		"name": "TIS5",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -23,13 +23,19 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/groups",
+							"raw": "http://{{host}}/groups?token=<token>",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
 							],
 							"path": [
 								"groups"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "<token>"
+								}
 							]
 						}
 					},
@@ -117,7 +123,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/groups/<id>",
+							"raw": "http://{{host}}/groups/<id>?token=<token>",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -125,6 +131,12 @@
 							"path": [
 								"groups",
 								"<id>"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "<token>"
+								}
 							]
 						}
 					},
@@ -145,7 +157,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/groups/<id>",
+							"raw": "http://{{host}}/groups/<id>?token=<token>",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -153,6 +165,12 @@
 							"path": [
 								"groups",
 								"<id>"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "<token>"
+								}
 							]
 						}
 					},
@@ -557,7 +575,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://{{host}}/messages/02b5fc11-157c-479a-a1ea-b04957e1a735",
+							"raw": "http://{{host}}/messages/02b5fc11-157c-479a-a1ea-b04957e1a735?token=<token>",
 							"protocol": "http",
 							"host": [
 								"{{host}}"
@@ -565,6 +583,12 @@
 							"path": [
 								"messages",
 								"02b5fc11-157c-479a-a1ea-b04957e1a735"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "<token>"
+								}
 							]
 						}
 					},

--- a/flood/endpoints/groups.py
+++ b/flood/endpoints/groups.py
@@ -4,7 +4,7 @@
 import flood.models.group as group_model
 
 from flask import Blueprint, jsonify, request
-from flood.utils import body_validations, query_param_validations
+from flood.utils import body_validations, query_param_validations, jwt_token
 from flood.endpoints import endpoints_exception
 
 import logging
@@ -30,6 +30,7 @@ def get_groups():
 
 
 @blueprint.route('/groups', methods=['POST'])
+@jwt_token.token_required
 def post_group():
     body = request.json
     body_validations.validate_group(body)
@@ -46,6 +47,7 @@ def get_group(group_id):
 
 
 @blueprint.route('/groups/<group_id>', methods=['DELETE'])
+@jwt_token.token_required
 def delete_group(group_id):
     group = group_model.delete(group_id)
     if group is None:
@@ -55,6 +57,7 @@ def delete_group(group_id):
 
 
 @blueprint.route('/groups/<group_id>', methods=['PUT'])
+@jwt_token.token_required
 def update_group(group_id):
     body = request.json
 

--- a/flood/endpoints/messages.py
+++ b/flood/endpoints/messages.py
@@ -73,6 +73,7 @@ def get_message(message_id):
 
 
 @blueprint.route('/messages/<message_id>', methods=['DELETE'])
+@jwt_token.token_required
 def delete_message(message_id):
     message = message_model.delete(message_id)
     if message is None:

--- a/flood/endpoints/messages.py
+++ b/flood/endpoints/messages.py
@@ -4,6 +4,7 @@
 import flood.models.message as message_model
 import flood.models.group as group_model
 import flood.models.user as user_model
+import flood.models.user_groups as user_group_model
 from flask import Blueprint, jsonify, request
 from flood.utils import body_validations, query_param_validations, jwt_token
 from flood.endpoints import endpoints_exception
@@ -50,13 +51,17 @@ def post_message():
     group = group_model.get(request.args['group_id'])
     if group is None:
         raise endpoints_exception(404, "GROUP_NOT_FOUND")
-    user = user_model.get(request.args['user_id'])
 
+    user = user_model.get(request.args['user_id'])
     if user is None:
         raise endpoints_exception(404, "USER_NOT_FOUND")
 
-    message = message_model.create(body['text'], user, group)
-    return jsonify(message.to_dict()), 200
+    user_groups = user_group_model.check_user_group(user, group)
+    if user_groups is not None:
+        message = message_model.create(body['text'], user, group)
+        return jsonify(message.to_dict()), 200
+    else:
+        raise endpoints_exception(404, "USER_NOT_IN_GROUP_FOUND")
 
 
 @blueprint.route('/messages/<message_id>', methods=['GET', 'OPTIONS'])

--- a/flood/endpoints/users.py
+++ b/flood/endpoints/users.py
@@ -32,9 +32,13 @@ def get_users():
 def post_user():
     body = request.json
     body_validations.validate_user(body)
-    body['pswd'] = password_utils.convert_md5(body['pswd'])
-    user = user_model.create(body)
-    return jsonify(user.to_dict()), 200
+    existing_user = user_model.get_by_email(body['email'])
+    if existing_user:
+        raise endpoints_exception(403, "EMAIL_ALREADY_IN_USE")
+    else:
+        body['pswd'] = password_utils.convert_md5(body['pswd'])
+        user = user_model.create(body)
+        return jsonify(user.to_dict()), 200
 
 
 @blueprint.route('/users/<user_id>', methods=['GET', 'OPTIONS'])

--- a/flood/models/user_groups.py
+++ b/flood/models/user_groups.py
@@ -91,3 +91,18 @@ def get_user_groups(session, user):
             r = to_dict(row.group)
             groups.append(build_group_from_row(r))
         return groups
+
+
+@db_session
+def check_user_group(session, user, group):
+    _logger.info(
+        "CHECKING_USER_GROUPS: ".format(user.to_dict()),
+    )
+
+    result = session.query(UserGroup).join(Group).filter(UserGroup.user_id == user.id)\
+        .filter(UserGroup.group_id == group.id).first()
+
+    if result is None:
+        return None
+    else:
+        return buid_object_from_row(to_dict(result))


### PR DESCRIPTION
- Validação via Token JWT foi também agora adicionada aos seguintes Endpoints:
  - POST /groups
  - DELETE /groups/<group_id>
  - PUT /group/<group_id>
  - DELETE /messages/<message_id>
- Obs: Validação é feita via o parâmetro "**token**"  no HTTP request da query.

