### PR TITLE
Adiciona data e hora de criação do tweet ao corpo da resposta

### DIFF
--- a/flood/utils/tweepy.py
+++ b/flood/utils/tweepy.py
@@ -1,9 +1,11 @@
 from tweepy import OAuthHandler, API, error, Cursor
 import os
+from datetime import timedelta
 from flood.endpoints import endpoints_exception
 
 
 def to_dict(tweet):
+    dt = tweet.created_at - timedelta(hours=3)
     result = {
         "tweet_user_name": tweet.user.name,
         "tweet_user_screen_name": tweet.user.screen_name,
@@ -11,6 +13,7 @@ def to_dict(tweet):
         "tweet_url": "https://twitter.com/{0}/status/{1}".format(tweet.user.screen_name, tweet.id),
         "favorite_count": tweet.favorite_count,
         "retweet_count": tweet.retweet_count,
+        "created_at": dt.strftime("%a ,%d-%m-%Y %H:%M:%S")
     }
     return result
 
@@ -27,8 +30,7 @@ def get_user_timeline_tweets(num_tweets, user):
         for tweet in Cursor(authenticate_twitter_app().user_timeline, id=user, tweet_mode='extended').items(num_tweets):
             tweets.append(to_dict(tweet))
         return tweets
-    except error.TweepError:
-        raise endpoints_exception(500, "APPLICATION FAILED TO MAINTAIN CONNECTION WITH TWITTER")
     except error.RateLimitError:
         raise endpoints_exception(429, "NUMBER OF REQUESTS PER HOUR HAS BEEN EXCEEDED")
-
+    except error.TweepError:
+        raise endpoints_exception(500, "APPLICATION FAILED TO MAINTAIN CONNECTION WITH TWITTER")


### PR DESCRIPTION
- Endpoint GET /twitter agora retornar data e hora de criação dos tweets no seguinte formato:
  - Dia da Semana, Dia-Mês-Ano Hora:Minuto:Segundo

